### PR TITLE
Fix: Admin-Modus ermöglicht Bearbeitung fremder Shortcuts/Ordner

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,6 +92,7 @@ function setAdminMode(on){
 function checkAdminExpiry(){
   if(adminMode && Date.now() > adminExpiresAt){
     setAdminMode(false);
+    render(); // UI aktualisieren, damit Options-Buttons bei fremden Elementen verschwinden
   }
 }
 setInterval(checkAdminExpiry, 1000);
@@ -618,6 +619,7 @@ function promptFolderPassword(f){
         setAdminMode(true);
         hideDialog();
         alert('Admin-Modus aktiviert für 30 Minuten ✅');
+        render(); // UI aktualisieren, damit Admin alle Elemente bearbeiten kann
         resolve(true);
         return;
       }


### PR DESCRIPTION
## Summary
- UI wird jetzt nach Admin-Aktivierung neu gerendert, sodass Options-Buttons (⋮) bei allen Shortcuts/Ordnern erscheinen
- UI wird auch nach Admin-Ablauf aktualisiert, damit die Buttons wieder verschwinden
- Ermöglicht Admins das Bearbeiten, Verschieben und Löschen von fremden Elementen

## Test plan
- [ ] Als normaler User einloggen und verifizieren, dass man nur eigene Elemente bearbeiten kann
- [ ] Admin-Passwort bei einem gesperrten Ordner eingeben
- [ ] Verifizieren, dass nach Aktivierung die ⋮-Buttons bei ALLEN Shortcuts/Ordnern erscheinen
- [ ] Einen fremden Shortcut bearbeiten/löschen
- [ ] Einen fremden Ordner bearbeiten/entsperren/löschen

🤖 Generated with [Claude Code](https://claude.com/claude-code)